### PR TITLE
README: binary is misleading

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Bitcoin BIP32 ("HD Wallet") path helpers.
 There are multiple path representations being used by different implementations. These includes:
 - `m/44'/0'/0'/0/0` where the apostrophe means hardened key
 - `m/44h/0h/0h/0/0` where the letter `h` means hardened key
-- and a binary representation predominantly used by Trezor & compatible wallets and some software tools, such as [bitcoinjs-lib](https://github.com/bitcoinjs/bitcoinjs-lib)
+- and an `Array` representation used by Trezor & compatible wallets and some software tools, such as [bitcoinjs-lib](https://github.com/bitcoinjs/bitcoinjs-lib)
 
 Some useful links:
 - [BIP32 specification](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
@@ -17,14 +17,14 @@ Some useful links:
 ### API
 
 - `BIPPath.fromString(path, reqRoot)` - creates an instance from a path written as text. Set `reqRoot` to true if the `m/` prefix is mandatory.
-- `BIPPath.fromPathArray(path)` - creates an instance from a binary path array
+- `BIPPath.fromPathArray(path)` - creates an instance from a path array
 - `new BIPPath(path)` - alias for `BIPPath.fromPathArray(path)`
 - `<bippath>.toString(noRoot, oldStyle)` - returns a text encoded path. Set to `noRoot` to true to omit the `m/` prefix. Set `oldStyle` true to use `h` instead of `'` for marking hardened nodes.
-- `<bippath>.toPathArray()` - returns a binary path array
+- `<bippath>.toPathArray()` - returns a path array
 - `BIPPath.validateString(path, reqRoot)` - returns true if the input is a valid path string
-- `BIPPath.validatePathArray(path)` - returns true if the input is a valid binary path array
+- `BIPPath.validatePathArray(path)` - returns true if the input is a valid path array
 
-Binary path arrays contain each node as a separate number, where hardened nodes are marked by setting the 32th bit: `m/44'/1/1/0` corresponds to `[ 0x8000002c, 1, 1, 0 ]`
+Path arrays contain each node as a separate number, where hardened nodes are marked by setting the highest bit: `m/44'/1/1/0` corresponds to `[ 0x8000002c, 1, 1, 0 ]`
 
 
 ### Examples


### PR DESCRIPTION
My impression was that you meant a `Buffer` format - which was confusing.

The "Path Array" format is more like an array of `uint32_t` words,  a Word Array,  as you may.